### PR TITLE
Fixed clustering issues due to differences in image size

### DIFF
--- a/BoxTheJets/aggregation/workflow.py
+++ b/BoxTheJets/aggregation/workflow.py
@@ -1026,7 +1026,7 @@ class Aggregator:
 
         return np.asarray(clust_starts), np.asarray(clust_ends)
             
-    def filter_classifications(self, subject, do_transform=False):
+    def filter_classifications(self, subject):
         '''
             Find a list of unique jets in the subject
             and segregate the classifications into each cluster 

--- a/BoxTheJets/aggregation/workflow.py
+++ b/BoxTheJets/aggregation/workflow.py
@@ -49,6 +49,7 @@ def get_subject_image(subject, frame=7):
     
     img = io.imread(frame0_url)
 
+    # for subjects that have an odd size, resize them
     if img.shape[0] != 1920:
         img = transform.resize(img, (1440, 1920))
 
@@ -86,7 +87,8 @@ def create_gif(jets):
 
     ims = []
     for i in range(15):
-        im1 = ax.imshow(get_subject_image(subject, i))
+        img = get_subject_image(subject, i)
+        im1 = ax.imshow(img)
         jetims = []
         for jet in jets:
             jetims.extend(jet.plot(ax))
@@ -1024,7 +1026,7 @@ class Aggregator:
 
         return np.asarray(clust_starts), np.asarray(clust_ends)
             
-    def filter_classifications(self, subject):
+    def filter_classifications(self, subject, do_transform=False):
         '''
             Find a list of unique jets in the subject
             and segregate the classifications into each cluster 
@@ -1159,7 +1161,10 @@ class Aggregator:
                 jets[index].end_extracts[key.replace('_end','')].append(combined_ends[key][i])
         
         fig, ax = plt.subplots(1, 1, dpi=150)
-        ax.imshow(get_subject_image(subject))
+
+
+        img = get_subject_image(subject)
+        ax.imshow(img)
 
         x_s = [*point_data_T1['x_start'], *point_data_T5['x_start']]
         y_s = [*point_data_T1['y_start'], *point_data_T5['y_start']]
@@ -1245,11 +1250,9 @@ class Jet:
         #baseplot, = ax.plot(base_points[:,0], base_points[:,1], 'y--')
         #heightplot, = ax.plot(height_points[:,0], height_points[:,1], 'k--')
 
-        arrowplot = ax.arrow(*point0, vec[0], vec[1], color='k', length_includes_head=True, head_width=25)
-        center_plot, = ax.plot(*center, 'kx')
+        arrowplot = ax.arrow(*point0, vec[0], vec[1], color='white', length_includes_head=True, head_width=25)
 
-
-        return [boxplot, startplot, endplot, startextplot, endextplot, *boxextplots, arrowplot, center_plot]
+        return [boxplot, startplot, endplot, startextplot, endextplot, *boxextplots, arrowplot]
 
     def autorotate(self):
         box_points   = np.transpose(self.box.exterior.xy)[:4,:]

--- a/BoxTheJets/aggregation/workflow.py
+++ b/BoxTheJets/aggregation/workflow.py
@@ -6,7 +6,7 @@ import matplotlib.animation as animation
 import ast
 import json
 from panoptes_client import Panoptes, Subject, Workflow
-from skimage import io
+from skimage import io, transform
 import getpass
 from shapely.geometry import Polygon, Point
 
@@ -48,6 +48,9 @@ def get_subject_image(subject, frame=7):
         frame0_url = subjecti.raw['locations'][frame]['image/jpeg']
     
     img = io.imread(frame0_url)
+
+    if img.shape[0] != 1920:
+        img = transform.resize(img, (1440, 1920))
 
     return img
 

--- a/BoxTheJets/scripts/do_aggregation.sh
+++ b/BoxTheJets/scripts/do_aggregation.sh
@@ -6,24 +6,25 @@ mkdir -p {extracts,reductions}/
 cd extracts/;
 panoptes_aggregation extract ../box-the-jets-classifications.csv ../configs/Extractor_config_workflow_19650_V4.52.yaml -o box_the_jets
 
-# # squash the frames
+# squash the frames
 cd ..;
+python3 scripts/normalize_subject_size.py
 python3 scripts/squash_frames.py
 
 # then do the reductions
 cd reductions/
-panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_squashed.csv \
-    ../configs/Reducer_config_workflow_19650_V4.52_point_extractor_by_frame.yaml -o box_the_jets
-panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_squashed_merged.csv \
-    ../configs/Reducer_config_workflow_19650_V4.52_point_extractor_by_frame.yaml -o box_the_jets_merged
+panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_scaled_squashed.csv \
+    ../configs/Reducer_config_workflow_19650_V4.52_point_extractor_by_frame.yaml -o box_the_jets_scaled
+#panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_squashed_merged.csv \
+#    ../configs/Reducer_config_workflow_19650_V4.52_point_extractor_by_frame.yaml -o box_the_jets_merged
 
 # Using the old euclidian metric for clustering
 #panoptes_aggregation reduce ../extracts/shape_extractor_rotateRectangle_box_the_jets_squashed.csv\
 #    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle.yaml -o box_the_jets
 
 # Using the new jaccard metric for clustering
-panoptes_aggregation reduce ../extracts/shape_extractor_rotateRectangle_box_the_jets_squashed.csv\
-    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle_IoU.yaml -o box_the_jets
+panoptes_aggregation reduce ../extracts/shape_extractor_rotateRectangle_box_the_jets_scaled_squashed.csv \
+    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle_IoU.yaml -o box_the_jets_scaled -c 15
 
 panoptes_aggregation reduce ../extracts/question_extractor_box_the_jets.csv\
     ../configs/Reducer_config_workflow_19650_V4.52_question_extractor.yaml -o box_the_jets

--- a/BoxTheJets/scripts/do_aggregation.sh
+++ b/BoxTheJets/scripts/do_aggregation.sh
@@ -14,7 +14,7 @@ python3 scripts/squash_frames.py
 # then do the reductions
 cd reductions/
 panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_scaled_squashed.csv \
-    ../configs/Reducer_config_workflow_19650_V4.52_point_extractor_by_frame.yaml -o box_the_jets_scaled
+    ../configs/Reducer_config_workflow_19650_V4.52_point_extractor_by_frame.yaml -o box_the_jets
 #panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_squashed_merged.csv \
 #    ../configs/Reducer_config_workflow_19650_V4.52_point_extractor_by_frame.yaml -o box_the_jets_merged
 
@@ -24,7 +24,7 @@ panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_sc
 
 # Using the new jaccard metric for clustering
 panoptes_aggregation reduce ../extracts/shape_extractor_rotateRectangle_box_the_jets_scaled_squashed.csv \
-    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle_IoU.yaml -o box_the_jets_scaled -c 15
+    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle_IoU.yaml -o box_the_jets
 
 panoptes_aggregation reduce ../extracts/question_extractor_box_the_jets.csv\
     ../configs/Reducer_config_workflow_19650_V4.52_question_extractor.yaml -o box_the_jets

--- a/BoxTheJets/scripts/normalize_subject_size.py
+++ b/BoxTheJets/scripts/normalize_subject_size.py
@@ -1,0 +1,132 @@
+from panoptes_client import Workflow, SubjectSet, Subject
+from astropy.io import ascii
+from astropy.table import Table
+from skimage import io
+import numpy as np
+from multiprocessing import Pool
+import tqdm
+import signal
+import time
+
+FETCH_FROM_PANOPTES = False
+
+def initializer():
+    '''
+        Ignore CTRL+C in the worker process
+    '''
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+def get_subject_scale(subject_id):
+    '''
+        Get the scale for all frames for a given subject.
+        Loads the subject from Panoptes and gets the image 
+        sizes by directly opening the image
+    '''
+    try:
+        # create the subject object 
+        subject = Subject(subject_id)
+        widths  = np.zeros(15)
+        heights = np.zeros(15)
+        
+        # loop through the frames
+        for frame in range(15):
+            # get the image URL on panoptes
+            try:
+                frame_url = subject.raw['locations'][frame]['image/png']
+            except KeyError:
+                frame_url = subject.raw['locations'][frame]['image/jpeg']
+
+            # read the image from the url 
+            img = io.imread(frame_url)
+            # and get its shape
+            ny, nx, _ = img.shape
+
+            widths[frame]  = nx
+            heights[frame] = ny
+
+        # the standard size is 1920x1440 so 
+        # we will scale everything else to that size
+        scale = widths/1920.
+
+        # add this info to the table
+        data = [int(subject.id), *scale]
+        
+        return data
+    except Exception as e:
+        return None
+
+def get_scales_set(save=True):
+    '''
+        Process data for all subjects in the subject set
+        and retrieve the corresponding scale wrt. the 1920x1440
+        standard
+    '''
+    # create the column names and associated datatypes
+    names  = ['subject_id']
+    dtypes = ['i4']
+    for i in range(15):
+        names.append(f'frame_{i}_scale')
+        dtypes.append('f4')
+
+    # and initialize the empty table so we can add 
+    # rows later on
+    table = Table(names=names, dtype=dtypes)
+
+    if FETCH_FROM_PANOPTES:
+        workflow = Workflow(19650)
+        subject_set = workflow.links.subject_sets[0]
+
+        subjects = []
+        for subject in subject_set:
+            subjects.append(subject.id)
+    else:
+        subject_data = ascii.read('reductions/point_reducer_hdbscan_box_the_jets.csv')
+        subjects     = list(np.unique(subject_data['subject_id']))
+
+    # run this process in parallel since there is a lot of 
+    # waiting for the API callback
+    run = 0
+    with Pool(initializer=initializer) as pool:
+        print(f"Running with {pool._processes} threads")
+        while len(subjects) > 0:
+            print(f"Pass {run+1}")
+            try:
+                r = tqdm.tqdm(pool.imap_unordered(get_subject_scale, subjects), total=len(subjects))
+
+                pool.close()
+
+                ninpt = len(subjects)
+
+                nfailed = 0
+                for result in r:
+                    # add the result to the table
+                    if result is not None:
+                        # the subject was downloaded successfully
+                        # so we can extract the scales
+                        table.add_row(result)
+
+                        # remove this subject from the queue
+                        subjects.remove(result[0])
+                    else:
+                        # there was an issue with the download
+                        # we will queue this subject to try again
+                        nfailed += 1
+                    r.set_postfix({'errors': nfailed})
+
+            except KeyboardInterrupt:
+                pool.terminate()
+                pool.join()
+            except Exception as e:
+                raise(e)
+
+            pool.join()
+
+            run += 1
+
+    if save:
+        table.write('configs/subject_scales.csv', format='csv', overwrite=True)
+    
+    return table
+
+if __name__=='__main__':
+    get_scales_set(False)

--- a/BoxTheJets/scripts/squash_frames.py
+++ b/BoxTheJets/scripts/squash_frames.py
@@ -3,7 +3,7 @@ from astropy.io import ascii
 import ast
 
 ## point extractor
-file = 'extracts/point_extractor_by_frame_box_the_jets.csv'
+file = 'extracts/point_extractor_by_frame_box_the_jets_scaled.csv'
 
 data = ascii.read(file, delimiter=',')
 
@@ -72,7 +72,7 @@ ascii.write(data, file.replace('.csv', '_squashed.csv'), overwrite=True, delimit
 ascii.write(data_merged, file.replace('.csv', '_squashed_merged.csv'), overwrite=True, delimiter=',')
 
 ## shape extractor
-file = 'extracts/shape_extractor_rotateRectangle_box_the_jets.csv'
+file = 'extracts/shape_extractor_rotateRectangle_box_the_jets_scaled.csv'
 
 data = ascii.read(file, delimiter=',')
 


### PR DESCRIPTION
Some subjects have frames that vary in size leading to differences in classification data. This was fixed by finding the scaling of each image relative to the standard 1920x1440 dimensions, and applying that scaling to the point/box extracts