### PR TITLE
Adding frame information for extractions and reductions

### DIFF
--- a/BoxTheJets/aggregation/SOL_class.py
+++ b/BoxTheJets/aggregation/SOL_class.py
@@ -450,8 +450,11 @@ class SOL:
                     box_metric[k, j] = 1. - box_ious
 
                     # we will limit to 2 frames (each frame is 5 min)
-                    time_metric[k, j] = np.abs((times[j] - times[k]).astype('timedelta64[s]')
-                                               .astype(float)) / (5 * 60 + 12)
+                    time_metric[k,j]  = np.abs( (times[j] - times[k]).astype('timedelta64[s]')\
+                                               .astype(float))
+
+        distance_metric = point_metric/np.percentile(point_metric[np.isfinite(point_metric)&(point_metric>0)], 99) + \
+                            2.*box_metric
 
         distance_metric = point_metric / np.percentile(point_metric[np.isfinite(point_metric) & (point_metric > 0)], 90) + \
             2. * box_metric
@@ -462,7 +465,7 @@ class SOL:
         labels = -1. * np.ones(len(jets))
         subjects = np.asarray([jet.subject for jet in jets])
 
-        print(f"Using eps={eps} and time_eps={time_eps*30} min")
+        print(f"Using eps={eps} and time_eps={time_eps/60} min")
 
         while len(indices) > 0:
             ind = indices[0]
@@ -552,7 +555,7 @@ class SOL:
 
             jet_clusters.append(clusteri)
 
-        return jet_clusters, distance_metric, point_metric, box_metric
+        return jet_clusters, distance_metric, point_metric, box_metric, time_metric
 
 
 class JetCluster:
@@ -583,12 +586,12 @@ class JetCluster:
             output: str
                 name of the exported gif
         '''
-        fig, ax = plt.subplots(1, 1, dpi=250)
-
+        fig, ax = plt.subplots(1,1, dpi=150)
+        
         # create a temp plot so that we can get a size estimate
         subject0 = self.jets[0].subject
-
-        ax.imshow(get_subject_image(subject0, 0))
+        
+        im1 = ax.imshow(get_subject_image(subject0, 0))
         ax.axis('off')
         fig.tight_layout(pad=0)
 
@@ -611,7 +614,7 @@ class JetCluster:
 
         # save the animation as a gif
         ani = animation.ArtistAnimation(fig, ims)
-        ani.save(output, writer='imagemagick')
+        ani.save(output, writer='ffmpeg')
         plt.close('all')
         
     def json_export(self,output):

--- a/BoxTheJets/aggregation/SOL_class.py
+++ b/BoxTheJets/aggregation/SOL_class.py
@@ -450,16 +450,8 @@ class SOL:
                     box_metric[k, j] = 1. - box_ious
 
                     # we will limit to 2 frames (each frame is 5 min)
-<<<<<<< HEAD
                     time_metric[k, j] = np.abs((times[j] - times[k]).astype('timedelta64[s]')
                                                .astype(float))
-=======
-                    time_metric[k,j]  = np.abs( (times[j] - times[k]).astype('timedelta64[s]')\
-                                               .astype(float))
-
-        distance_metric = point_metric/np.percentile(point_metric[np.isfinite(point_metric)&(point_metric>0)], 99) + \
-                            2.*box_metric
->>>>>>> 1f82d64567efe0bcbc43bfebca3a1dede6259352
 
         distance_metric = point_metric / np.percentile(point_metric[np.isfinite(point_metric) & (point_metric > 0)], 99) + \
             2. * box_metric
@@ -474,10 +466,6 @@ class SOL:
 
         while len(indices) > 0:
             ind = indices[0]
-<<<<<<< HEAD
-=======
-            # this is the jet we will compare against
->>>>>>> 1f82d64567efe0bcbc43bfebca3a1dede6259352
 
             # find all the jets that fall within a distance
             # eps for this jet and those that are not
@@ -625,13 +613,8 @@ class JetCluster:
         ani = animation.ArtistAnimation(fig, ims)
         ani.save(output, writer='ffmpeg')
         plt.close('all')
-<<<<<<< HEAD
 
     def json_export(self, output):
-=======
-        
-    def json_export(self,output):
->>>>>>> 1f82d64567efe0bcbc43bfebca3a1dede6259352
         '''
             export one single jet cluster to output.json file
             Inputs

--- a/BoxTheJets/aggregation/SOL_class.py
+++ b/BoxTheJets/aggregation/SOL_class.py
@@ -430,9 +430,9 @@ class SOL:
 
                     # we will limit to 2 frames (each frame is 5 min)
                     time_metric[k,j]  = np.abs( (times[j] - times[k]).astype('timedelta64[s]')\
-                                               .astype(float))/(5*60+12)
+                                               .astype(float))
 
-        distance_metric = point_metric/np.percentile(point_metric[np.isfinite(point_metric)&(point_metric>0)], 90) + \
+        distance_metric = point_metric/np.percentile(point_metric[np.isfinite(point_metric)&(point_metric>0)], 99) + \
                             2.*box_metric
 
 
@@ -442,7 +442,7 @@ class SOL:
         labels   = -1.*np.ones(len(jets))
         subjects = np.asarray([jet.subject for jet in jets])
 
-        print(f"Using eps={eps} and time_eps={time_eps*30} min")
+        print(f"Using eps={eps} and time_eps={time_eps/60} min")
 
         while len(indices) > 0:
             ind = indices[0]
@@ -533,7 +533,7 @@ class SOL:
 
             jet_clusters.append(clusteri)
 
-        return jet_clusters, distance_metric, point_metric, box_metric
+        return jet_clusters, distance_metric, point_metric, box_metric, time_metric
 
 
 class JetCluster:
@@ -564,12 +564,12 @@ class JetCluster:
             output: str
                 name of the exported gif 
         '''
-        fig, ax = plt.subplots(1,1, dpi=250)
+        fig, ax = plt.subplots(1,1, dpi=150)
         
         # create a temp plot so that we can get a size estimate
         subject0 = self.jets[0].subject
         
-        ax.imshow(get_subject_image(subject0, 0))
+        im1 = ax.imshow(get_subject_image(subject0, 0))
         ax.axis('off')
         fig.tight_layout(pad=0)
 
@@ -592,7 +592,7 @@ class JetCluster:
 
         # save the animation as a gif
         ani = animation.ArtistAnimation(fig, ims)
-        ani.save(output, writer='imagemagick')
+        ani.save(output, writer='ffmpeg')
         plt.close('all')
         
     def json_export(self,output):

--- a/BoxTheJets/aggregation/SOL_class.py
+++ b/BoxTheJets/aggregation/SOL_class.py
@@ -1,20 +1,11 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from IPython.display import Image, display
-from panoptes_client import Panoptes, Subject, Workflow
 from dateutil.parser import parse
-import ast
-import os
-import datetime
-from matplotlib.dates import DateFormatter
 import matplotlib.animation as animation
-from .workflow import Aggregator, Jet
+from .workflow import Jet
 from .workflow import get_subject_image, get_box_edges
-from sklearn.cluster import OPTICS
-from scipy.spatial.distance import squareform
-from scipy.cluster.hierarchy import linkage, fcluster
-from shapely.geometry import Polygon, Point
-import hdbscan
+from shapely.geometry import Polygon
 import json
 import tqdm
 
@@ -278,7 +269,6 @@ class SOL:
                 name of the SOL event used in Zooniverse 
         '''
         subjects=self.get_subjects(SOL_event)
-        obs_time=self.get_obs_time(SOL_event)
 
         for subject in subjects:
             ## check to make sure that these subjects had classification
@@ -421,8 +411,6 @@ class SOL:
         time_metric  = np.zeros((len(jets), len(jets)))
         point_metric = np.zeros((len(jets), len(jets)))
 
-        dtime = (times_all[-1] - times_all[0]).astype('timedelta64[s]').astype(float)
-
         for j, jetj in enumerate(jets):
             for k, jetk in enumerate(jets):
                 if j==k:
@@ -459,7 +447,6 @@ class SOL:
         while len(indices) > 0:
             ind = indices[0]
             # this is the jet we will compare against
-            j0 = jets[ind]
 
             # find all the jets that fall within a distance 
             # eps for this jet and those that are not 
@@ -473,8 +460,6 @@ class SOL:
             if len(unique_subs) != sum(mask):
                 # in this case, there are duplicates
                 # we will choose the best subject from each duplicate
-                count = [sum(subjects[mask]==subject) for subject in unique_subs]
-
                 # loop through the unique subs
                 for sub in unique_subs:
                     # find the indices that correspond to this
@@ -608,6 +593,7 @@ class JetCluster:
         # save the animation as a gif
         ani = animation.ArtistAnimation(fig, ims)
         ani.save(output, writer='imagemagick')
+        plt.close('all')
         
     def json_export(self,output):
         '''

--- a/BoxTheJets/aggregation/SOL_class.py
+++ b/BoxTheJets/aggregation/SOL_class.py
@@ -479,7 +479,6 @@ class SOL:
             if len(unique_subs) != sum(mask):
                 # in this case, there are duplicates
                 # we will choose the best subject from each duplicate
-
                 # loop through the unique subs
                 for sub in unique_subs:
                     # find the indices that correspond to this
@@ -613,8 +612,9 @@ class JetCluster:
         # save the animation as a gif
         ani = animation.ArtistAnimation(fig, ims)
         ani.save(output, writer='imagemagick')
-
-    def json_export(self, output):
+        plt.close('all')
+        
+    def json_export(self,output):
         '''
             export one single jet cluster to output.json file
             Inputs

--- a/BoxTheJets/aggregation/SOL_class.py
+++ b/BoxTheJets/aggregation/SOL_class.py
@@ -450,13 +450,10 @@ class SOL:
                     box_metric[k, j] = 1. - box_ious
 
                     # we will limit to 2 frames (each frame is 5 min)
-                    time_metric[k,j]  = np.abs( (times[j] - times[k]).astype('timedelta64[s]')\
+                    time_metric[k, j] = np.abs((times[j] - times[k]).astype('timedelta64[s]')
                                                .astype(float))
 
-        distance_metric = point_metric/np.percentile(point_metric[np.isfinite(point_metric)&(point_metric>0)], 99) + \
-                            2.*box_metric
-
-        distance_metric = point_metric / np.percentile(point_metric[np.isfinite(point_metric) & (point_metric > 0)], 90) + \
+        distance_metric = point_metric / np.percentile(point_metric[np.isfinite(point_metric) & (point_metric > 0)], 99) + \
             2. * box_metric
 
         distance_metric[~np.isfinite(distance_metric)] = np.nan
@@ -586,11 +583,11 @@ class JetCluster:
             output: str
                 name of the exported gif
         '''
-        fig, ax = plt.subplots(1,1, dpi=150)
-        
+        fig, ax = plt.subplots(1, 1, dpi=150)
+
         # create a temp plot so that we can get a size estimate
         subject0 = self.jets[0].subject
-        
+
         im1 = ax.imshow(get_subject_image(subject0, 0))
         ax.axis('off')
         fig.tight_layout(pad=0)
@@ -616,8 +613,8 @@ class JetCluster:
         ani = animation.ArtistAnimation(fig, ims)
         ani.save(output, writer='ffmpeg')
         plt.close('all')
-        
-    def json_export(self,output):
+
+    def json_export(self, output):
         '''
             export one single jet cluster to output.json file
             Inputs

--- a/BoxTheJets/aggregation/workflow.py
+++ b/BoxTheJets/aggregation/workflow.py
@@ -281,6 +281,7 @@ class Aggregator:
                 Array of subject IDs on Zooniverse
         '''
         subjects = [e['subject_id'] for e in self.reductions_data]
+        # if min([len(e[key]['clusters']) for key in ['box','start','end']]) > 0]
 
         return np.unique(subjects)
 
@@ -313,21 +314,21 @@ class Aggregator:
 
         data = {}
 
-        data['x_start'] = points_data['start']['extracts']['x']
-        data['y_start'] = points_data['start']['extracts']['y']
-        data['x_end'] = points_data['end']['extracts']['x']
-        data['y_end'] = points_data['end']['extracts']['y']
+        data['x_start'] = np.asarray(points_data['start']['extracts']['x'])
+        data['y_start'] = np.asarray(points_data['start']['extracts']['y'])
+        data['x_end'] = np.asarray(points_data['end']['extracts']['x'])
+        data['y_end'] = np.asarray(points_data['end']['extracts']['y'])
 
         clusters = {}
-        clusters['x_start'] = points_data['start']['clusters']['x']
-        clusters['y_start'] = points_data['start']['clusters']['y']
-        clusters['x_end'] = points_data['end']['clusters']['x']
-        clusters['y_end'] = points_data['end']['clusters']['y']
+        clusters['x_start'] = np.asarray(points_data['start']['clusters']['x'])
+        clusters['y_start'] = np.asarray(points_data['start']['clusters']['y'])
+        clusters['x_end'] = np.asarray(points_data['end']['clusters']['x'])
+        clusters['y_end'] = np.asarray(points_data['end']['clusters']['y'])
 
-        clusters['prob_start'] = points_data['start']['extracts']['cluster_probabilities']
-        clusters['prob_end'] = points_data['start']['extracts']['cluster_probabilities']
-        clusters['labels_start'] = points_data['start']['extracts']['cluster_labels']
-        clusters['labels_end'] = points_data['start']['extracts']['cluster_labels']
+        clusters['prob_start'] = np.asarray(points_data['start']['extracts']['cluster_probabilities'])
+        clusters['prob_end'] = np.asarray(points_data['start']['extracts']['cluster_probabilities'])
+        clusters['labels_start'] = np.asarray(points_data['start']['extracts']['cluster_labels'])
+        clusters['labels_end'] = np.asarray(points_data['start']['extracts']['cluster_labels'])
 
         return data, clusters
 
@@ -361,21 +362,26 @@ class Aggregator:
 
         data = {}
 
-        data['x'] = box_data['box']['extracts']['x']
-        data['y'] = box_data['box']['extracts']['y']
-        data['w'] = box_data['box']['extracts']['width']
-        data['h'] = box_data['box']['extracts']['height']
-        data['a'] = box_data['box']['extracts']['angle']
+        data['x'] = np.asarray(box_data['box']['extracts']['x'])
+        data['y'] = np.asarray(box_data['box']['extracts']['y'])
+        data['w'] = np.asarray(box_data['box']['extracts']['width'])
+        data['h'] = np.asarray(box_data['box']['extracts']['height'])
+        data['a'] = np.asarray(box_data['box']['extracts']['angle'])
 
         clusters = {}
-        clusters['x'] = box_data['box']['clusters']['x']
-        clusters['y'] = box_data['box']['clusters']['y']
-        clusters['w'] = box_data['box']['clusters']['width']
-        clusters['h'] = box_data['box']['clusters']['height']
-        clusters['a'] = box_data['box']['clusters']['angle']
-        
-        clusters['sigma'] = box_data['box']['clusters']['sigma']
-        clusters['labels'] = box_data['box']['extracts']['cluster_labels']
+
+        try:
+            clusters['x'] = np.asarray(box_data['box']['clusters']['x'])
+            clusters['y'] = np.asarray(box_data['box']['clusters']['y'])
+            clusters['w'] = np.asarray(box_data['box']['clusters']['width'])
+            clusters['h'] = np.asarray(box_data['box']['clusters']['height'])
+            clusters['a'] = np.asarray(box_data['box']['clusters']['angle'])
+            
+            clusters['sigma'] = np.asarray(box_data['box']['clusters']['sigma'])
+        except Exception:
+            for key in ['x', 'y', 'w', 'h', 'a', 'sigma']:
+                clusters[key] = np.asarray([])
+        clusters['labels'] = np.asarray(box_data['box']['extracts']['cluster_labels'])
         try:
             clusters['prob'] = box_data['box']['extracts']['cluster_probabilities']
         except KeyError:

--- a/BoxTheJets/aggregation/workflow.py
+++ b/BoxTheJets/aggregation/workflow.py
@@ -6,6 +6,7 @@ import ast
 from panoptes_client import Panoptes, Subject
 from skimage import io, transform
 import getpass
+import json
 from shapely.geometry import Polygon, Point
 
 
@@ -254,7 +255,7 @@ class Aggregator:
         Single data class to handle different aggregation requirements
     '''
 
-    def __init__(self, points_file, box_file):
+    def __init__(self, reductions_file):
         '''
             Inputs
             ------
@@ -263,13 +264,12 @@ class Aggregator:
             box_file : str
                 path to the reduced box data
         '''
-        self.points_file = points_file
-        with open(points_file, 'r') as in_points:
-            self.points_data = json.load(in_points)
+        self.reductions_file = reductions_file
+        with open(reductions_file, 'r') as in_file:
+            self.reductions_data = json.load(in_file)
 
-        self.box_file = box_file
-        with open(box_file, 'r') as in_box:
-            self.box_data = json.load(in_box)
+        # get a list of unique subjects
+        self.subjects = self.get_subjects()
 
     def get_subjects(self):
         '''
@@ -280,10 +280,9 @@ class Aggregator:
             subjects : numpy.ndarray
                 Array of subject IDs on Zooniverse
         '''
-        points_subjects = [e['subject_id'] for e in self.points_data]
-        box_subjects = [e['subject_id'] for e in self.box_data]
+        subjects = [e['subject_id'] for e in self.reductions_data]
 
-        return np.unique([*points_subjects, *box_subjects])
+        return np.unique(subjects)
 
     def get_points_data(self, subject, task='T1'):
         '''
@@ -305,7 +304,7 @@ class Aggregator:
                 Cluster shape (x, y) for start and end and probabilities and labels of the
                 data points
         '''
-        points_data = list(filter(lambda e: e['subject_id'] == subject, self.points_data))
+        points_data = list(filter(lambda e: e['subject_id'] == subject, self.reductions_data))
 
         assert len(points_data) == 1, f"Found {len(points_data)} matching reductions for points data!"
 
@@ -352,45 +351,33 @@ class Aggregator:
                 Cluster shape (x, y, width, height and angle) and probabilities and labels of the
                 data points
         '''
-        box_data = self.box_data[:][(self.box_data['subject_id'] == subject) & (
-            self.box_data['task'] == task)]
+        
+        box_data = list(filter(lambda e: e['subject_id'] == subject, self.reductions_data))
 
-        box_data = box_data.filled()
+        assert len(box_data) == 1, f"Found {len(box_data)} matching reductions for box data!"
+
+        # extrac the dictionary for this subject
+        box_data = box_data[0]
 
         data = {}
 
-        data['x'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_rotateRectangle_x'][0]))
-        data['y'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_rotateRectangle_y'][0]))
-        data['w'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_rotateRectangle_width'][0]))
-        data['h'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_rotateRectangle_height'][0]))
-        data['a'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_rotateRectangle_angle'][0]))
+        data['x'] = box_data['box']['extracts']['x']
+        data['y'] = box_data['box']['extracts']['y']
+        data['w'] = box_data['box']['extracts']['width']
+        data['h'] = box_data['box']['extracts']['height']
+        data['a'] = box_data['box']['extracts']['angle']
 
         clusters = {}
-
-        clusters['x'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_clusters_x'][0]))
-        clusters['y'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_clusters_y'][0]))
-        clusters['w'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_clusters_width'][0]))
-        clusters['h'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_clusters_height'][0]))
-        clusters['a'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_clusters_angle'][0]))
-
-        clusters['sigma'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_clusters_sigma'][0]))
-        clusters['labels'] = np.asarray(ast.literal_eval(
-            box_data[f'data.frame0.{task}_tool2_cluster_labels'][0]))
-
+        clusters['x'] = box_data['box']['clusters']['x']
+        clusters['y'] = box_data['box']['clusters']['y']
+        clusters['w'] = box_data['box']['clusters']['width']
+        clusters['h'] = box_data['box']['clusters']['height']
+        clusters['a'] = box_data['box']['clusters']['angle']
+        
+        clusters['sigma'] = box_data['box']['clusters']['sigma']
+        clusters['labels'] = box_data['box']['extracts']['cluster_labels']
         try:
-            clusters['prob'] = np.asarray(ast.literal_eval(
-                box_data[f'data.frame0.{task}_tool2_cluster_probabilities'][0]))
+            clusters['prob'] = box_data['box']['extracts']['cluster_probabilities']
         except KeyError:
             # OPTICS cluster doesn't have probabilities
             probs = np.zeros(len(data['x']))
@@ -409,7 +396,7 @@ class Aggregator:
                     probs[i] = boxi_data.intersection(
                         boxi_clust).area/boxi_data.union(boxi_clust).area
             clusters['prob'] = probs
-
+        
         return data, clusters
 
     def plot_subject_both(self, subject):
@@ -637,11 +624,7 @@ class Aggregator:
         x1_i = points_data['x_end']
         y1_i = points_data['y_end']
 
-        cx0_i = points_clusters['x_start']
-        cy0_i = points_clusters['y_start']
         p0_i = points_clusters['prob_start']
-        cx1_i = points_clusters['x_end']
-        cy1_i = points_clusters['y_end']
         p1_i = points_clusters['prob_end']
 
         # get the extract data so that we can obtain frame_time info
@@ -761,11 +744,6 @@ class Aggregator:
         h_i = box_data['h']
         a_i = box_data['a']
 
-        cx_i = box_clusters['x']
-        cy_i = box_clusters['y']
-        cw_i = box_clusters['w']
-        ch_i = box_clusters['h']
-        ca_i = box_clusters['a']
         p0_i = box_clusters['prob']
 
         # get the extract data so that we can obtain frame_time info
@@ -826,9 +804,6 @@ class Aggregator:
 
         # the score is the sum of the probabilities at each frame
         score = [np.sum(weight) for weight in weights]
-
-        # get the number of classifications for each point in time
-        npoints = [len(starti) for starti in frames]
 
         return {'box_frames': frames, 'box_score': score}
 
@@ -1135,8 +1110,8 @@ class Aggregator:
 
             # add the box with the best iou to the cluster list
             # sum_ious = temp_box_ious[merge_mask]*temp_box_count[merge_mask]
-            sum_ious = temp_boxes['iou'][merge_mask] * \
-                temp_boxes['count'][merge_mask]
+            # sum_ious = temp_boxes['iou'][merge_mask] * \
+            #    temp_boxes['count'][merge_mask]
             # clust_boxes.append(\
             #    temp_clust_boxes[merge_mask][np.argmax(sum_ious)])
 

--- a/BoxTheJets/aggregation/workflow.py
+++ b/BoxTheJets/aggregation/workflow.py
@@ -264,16 +264,12 @@ class Aggregator:
                 path to the reduced box data
         '''
         self.points_file = points_file
-        self.points_data = ascii.read(points_file, delimiter=',')
+        with open(points_file, 'r') as in_points:
+            self.points_data = json.load(in_points)
 
         self.box_file = box_file
-        self.box_data = ascii.read(box_file, delimiter=',')
-
-        for col in self.box_data.colnames:
-            self.box_data[col].fill_value = '[]'
-
-        for col in self.points_data.colnames:
-            self.points_data[col].fill_value = '[]'
+        with open(box_file, 'r') as in_box:
+            self.box_data = json.load(in_box)
 
     def get_subjects(self):
         '''
@@ -284,12 +280,12 @@ class Aggregator:
             subjects : numpy.ndarray
                 Array of subject IDs on Zooniverse
         '''
-        points_subjects = self.points_data['subject_id']
-        box_subjects = self.points_data['subject_id']
+        points_subjects = [e['subject_id'] for e in self.points_data]
+        box_subjects = [e['subject_id'] for e in self.box_data]
 
         return np.unique([*points_subjects, *box_subjects])
 
-    def get_points_data(self, subject, task):
+    def get_points_data(self, subject, task='T1'):
         '''
             Get the points data and cluster, and associated probabilities and labels
             for a givens subject and task. s corresponds to the start and e corresponds to end
@@ -309,40 +305,30 @@ class Aggregator:
                 Cluster shape (x, y) for start and end and probabilities and labels of the
                 data points
         '''
-        points_data = self.points_data[:][(self.points_data['subject_id'] == subject) & (
-            self.points_data['task'] == task)]
+        points_data = list(filter(lambda e: e['subject_id'] == subject, self.points_data))
 
-        points_data = points_data.filled()
+        assert len(points_data) == 1, f"Found {len(points_data)} matching reductions for points data!"
+
+        # extrac the dictionary for this subject
+        points_data = points_data[0]
 
         data = {}
 
-        data['x_start'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool0_points_x'][0]))
-        data['y_start'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool0_points_y'][0]))
-        data['x_end'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool1_points_x'][0]))
-        data['y_end'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool1_points_y'][0]))
+        data['x_start'] = points_data['start']['extracts']['x']
+        data['y_start'] = points_data['start']['extracts']['y']
+        data['x_end'] = points_data['end']['extracts']['x']
+        data['y_end'] = points_data['end']['extracts']['y']
 
         clusters = {}
-        clusters['x_start'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool0_clusters_x'][0]))
-        clusters['y_start'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool0_clusters_y'][0]))
-        clusters['x_end'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool1_clusters_x'][0]))
-        clusters['y_end'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool1_clusters_y'][0]))
+        clusters['x_start'] = points_data['start']['clusters']['x']
+        clusters['y_start'] = points_data['start']['clusters']['y']
+        clusters['x_end'] = points_data['end']['clusters']['x']
+        clusters['y_end'] = points_data['end']['clusters']['y']
 
-        clusters['prob_start'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool0_cluster_probabilities'][0]))
-        clusters['labels_start'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool0_cluster_labels'][0]))
-        clusters['prob_end'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool1_cluster_probabilities'][0]))
-        clusters['labels_end'] = np.asarray(ast.literal_eval(
-            points_data[f'data.frame0.{task}_tool1_cluster_labels'][0]))
+        clusters['prob_start'] = points_data['start']['extracts']['cluster_probabilities']
+        clusters['prob_end'] = points_data['start']['extracts']['cluster_probabilities']
+        clusters['labels_start'] = points_data['start']['extracts']['cluster_labels']
+        clusters['labels_end'] = points_data['start']['extracts']['cluster_labels']
 
         return data, clusters
 

--- a/BoxTheJets/aggregation/workflow.py
+++ b/BoxTheJets/aggregation/workflow.py
@@ -326,9 +326,9 @@ class Aggregator:
         clusters['y_end'] = np.asarray(points_data['end']['clusters']['y'])
 
         clusters['prob_start'] = np.asarray(points_data['start']['extracts']['cluster_probabilities'])
-        clusters['prob_end'] = np.asarray(points_data['start']['extracts']['cluster_probabilities'])
+        clusters['prob_end'] = np.asarray(points_data['end']['extracts']['cluster_probabilities'])
         clusters['labels_start'] = np.asarray(points_data['start']['extracts']['cluster_labels'])
-        clusters['labels_end'] = np.asarray(points_data['start']['extracts']['cluster_labels'])
+        clusters['labels_end'] = np.asarray(points_data['end']['extracts']['cluster_labels'])
 
         return data, clusters
 
@@ -1376,6 +1376,10 @@ class Aggregator:
 
         # and the unique clusters
         unique_jets = self.find_unique_jets(subject)
+
+        if len(unique_jets['box']) < 1:
+            return []
+
         unique_starts, unique_ends = self.find_unique_jet_points(subject)
 
         # combine the T1 and T5 raw data

--- a/BoxTheJets/scripts/do_aggregation.sh
+++ b/BoxTheJets/scripts/do_aggregation.sh
@@ -43,7 +43,7 @@ panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_sc
 #    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle.yaml -o box_the_jets
 
 # Using the new jaccard metric for clustering
-panoptes_aggregation reduce ../extracts/shape_extractor_rotateRectangle_box_the_jets_scaled_squashed.csv \
+panoptes_aggregation reduce ../extracts/shape_extractor_rotateRectangle_box_the_jets_scaled_squashed_merged.csv \
     ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle.yaml \
 	-o box_the_jets -c ${NUM_PROCS}
 

--- a/BoxTheJets/scripts/do_aggregation.sh
+++ b/BoxTheJets/scripts/do_aggregation.sh
@@ -43,9 +43,11 @@ panoptes_aggregation reduce ../extracts/point_extractor_by_frame_box_the_jets_sc
 #    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle.yaml -o box_the_jets
 
 # Using the new jaccard metric for clustering
-panoptes_aggregation reduce ../extracts/shape_extractor_rotateRectangle_box_the_jets_scaled_squashed_merged.csv \
-    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle.yaml \
-	-o box_the_jets -c ${NUM_PROCS}
+cd ..;
+python3 scripts/do_reduction.py -c ${NUM_PROCS}
+#panoptes_aggregation reduce ../extracts/shape_extractor_rotateRectangle_box_the_jets_scaled_squashed_merged.csv \
+#    ../configs/Reducer_config_workflow_19650_V4.52_shape_extractor_rotateRectangle.yaml \
+#	-o box_the_jets -c ${NUM_PROCS}
 
 panoptes_aggregation reduce ../extracts/question_extractor_box_the_jets.csv\
     ../configs/Reducer_config_workflow_19650_V4.52_question_extractor.yaml -o box_the_jets

--- a/BoxTheJets/scripts/do_reduction.py
+++ b/BoxTheJets/scripts/do_reduction.py
@@ -52,7 +52,7 @@ def _do_reduction(box_data_sub, point_data_sub, subject):
 
     box_out = {}
     box_out['clusters'] = []
-    labels = np.asarray(box_reduction['frame0'][f'T1_tool2_cluster_labels'])
+    labels = np.asarray(box_reduction['frame0']['T1_tool2_cluster_labels'])
 
     # check if clusters were found
     if 'T1_tool2_clusters_x' in box_reduction['frame0']:
@@ -62,7 +62,7 @@ def _do_reduction(box_data_sub, point_data_sub, subject):
         box_out['clusters'] = defaultdict(list)
 
         # load in individual keys for the box properties
-        for key in ['x', 'y', 'width', 'height', 'angle']: 
+        for key in ['x', 'y', 'width', 'height', 'angle', 'sigma']: 
             for cluster in range(nclusters):
                 box_out['clusters'][key].append(box_reduction['frame0'][f'T1_tool2_clusters_{key}'][cluster])
             
@@ -153,9 +153,7 @@ def _do_reduction(box_data_sub, point_data_sub, subject):
     out_row['end'] = points_out['end']
     out_row['subject_id'] = subject
 
-    out_data.append(out_row)
-
-    return out_data
+    return out_row
 
 
 if __name__=='__main__':

--- a/BoxTheJets/scripts/do_reduction.py
+++ b/BoxTheJets/scripts/do_reduction.py
@@ -1,0 +1,241 @@
+from astropy.io import ascii
+from multiprocessing import Pool
+import argparse
+import numpy as np
+from collections import defaultdict
+import tqdm
+from ast import literal_eval
+from panoptes_aggregation.reducers.shape_reducer_dbscan import shape_reducer_dbscan
+from panoptes_aggregation.reducers.point_reducer_hdbscan import point_reducer_hdbscan
+import signal
+import json
+import time
+
+class NpEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return super(NpEncoder, self).default(obj)
+
+def initializer():
+    """Ignore CTRL+C in the worker process."""
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def _do_reduction(box_data_sub, point_data_sub, subject):
+    ext_data = []
+
+    for row in box_data_sub:
+        # format this in the dictionary structure that the reducer expects
+        exti = {'frame0': {}}
+
+        for key in ['x', 'y', 'width', 'height', 'angle', 'frame']: 
+            # load in the extractor data to a list
+            exti['frame0'][f'T1_tool2_{key}'] =\
+                literal_eval(row[f'data.frame0.T1_tool2_{key}'])
+
+        ext_data.append(exti)
+     
+    # do the reduction
+    box_reduction = shape_reducer_dbscan(ext_data, metric_type='IoU',
+                               shape='rotateRectangle', user_id=False, 
+                               allow_single_cluster=True, min_samples=2,
+                                min_cluster_size=2, eps=0.5)
+
+    if 'frame0' not in box_reduction.keys():
+        print(ext_data)
+        print(box_reduction)
+
+    box_out = {}
+    box_out['clusters'] = []
+    labels = np.asarray(box_reduction['frame0'][f'T1_tool2_cluster_labels'])
+
+    # check if clusters were found
+    if 'T1_tool2_clusters_x' in box_reduction['frame0']:
+        # if they were, then we load each cluster individually
+        nclusters = len(box_reduction['frame0']['T1_tool2_clusters_x'])
+
+        box_out['clusters'] = defaultdict(list)
+
+        # load in individual keys for the box properties
+        for key in ['x', 'y', 'width', 'height', 'angle']: 
+            for cluster in range(nclusters):
+                box_out['clusters'][key].append(box_reduction['frame0'][f'T1_tool2_clusters_{key}'][cluster])
+            
+    
+    # also save the extracts
+    box_out['extracts'] = []
+    ext_new = defaultdict(list)
+    for key in ['x', 'y', 'width', 'height', 'angle','frame']: 
+        key_data = []
+        for exti in ext_data:
+            key_data.extend(exti['frame0'][f'T1_tool2_{key}'])
+        
+        ext_new[key] = key_data
+    # and their corresponding cluster properties 
+    # (i.e. which cluster they belong to)
+    ext_new['cluster_labels'] = labels.tolist()
+        
+    # revert to a normal dict structure rather than
+    # the defaultdict
+    box_out['extracts'] = dict(ext_new)
+    
+    # do the same for the points
+    ext_data = []
+
+    for row in point_data_sub:
+        # format this in the dictionary structure that the reducer expects
+        exti = {'frame0': {}}
+
+        for key in ['x', 'y', 'frame']: 
+            for tool in ['tool0', 'tool1']:
+            # load in the extractor data to a list
+                exti['frame0'][f'T1_{tool}_{key}'] =\
+                    literal_eval(row[f'data.frame0.T1_{tool}_{key}'])
+
+        ext_data.append(exti)
+     
+    # do the reduction
+    point_reduction = point_reducer_hdbscan(ext_data, user_id=False, 
+                               allow_single_cluster=True, min_samples=2,
+                                min_cluster_size=2)
+    points_out = {}
+    points_out['start'] = {}
+    points_out['end'] = {}
+
+    out_key = {'tool0': 'start', 'tool1': 'end'}
+
+    for tool in ['tool0', 'tool1']:
+        out_keyi = out_key[tool]
+        points_out[out_keyi]['clusters'] = []
+        labels = np.asarray(point_reduction['frame0'][f'T1_{tool}_cluster_labels'])
+        probs = np.asarray(point_reduction['frame0'][f'T1_{tool}_cluster_probabilities'])
+
+        # check if clusters were found
+        if f'T1_{tool}_clusters_x' in point_reduction['frame0']:
+            # if they were, then we load each cluster individually
+            nclusters = len(point_reduction['frame0'][f'T1_{tool}_clusters_x'])
+
+            points_out[out_keyi]['clusters'] = defaultdict(list)
+            for cluster in range(nclusters):
+                # load in individual keys for the box properties
+                for key in ['x', 'y']: 
+                    points_out[out_keyi]\
+                        ['clusters'][key].append(\
+                            point_reduction['frame0'][f'T1_{tool}_clusters_{key}'][cluster])
+
+        # also save the extracts
+        points_out[out_keyi]['extracts'] = []
+        ext_new = defaultdict(list)
+        for key in ['x', 'y', 'frame']: 
+            key_data = []
+            for exti in ext_data:
+                key_data.extend(exti['frame0'][f'T1_{tool}_{key}'])
+            
+            ext_new[key] = key_data
+        # and their corresponding cluster properties 
+        # (i.e. which cluster they belong to)
+        ext_new['cluster_labels'] = labels.tolist()
+        ext_new['cluster_probabilities'] = probs.tolist()
+        
+        # revert to a normal dict structure rather than
+        # the defaultdict
+        points_out[out_keyi]['extracts'] = dict(ext_new)
+
+    # combine all these data sources into one big dict
+    out_row = {}
+    out_row['box'] = box_out
+    out_row['start'] = points_out['start']
+    out_row['end'] = points_out['end']
+    out_row['subject_id'] = subject
+
+    out_data.append(out_row)
+
+    return out_data
+
+
+if __name__=='__main__':
+    parser = argparse.ArgumentParser(description='Reduce Solar Jet Hunter data')
+    parser.add_argument('-c', '--num_procs', metavar='n', type=int,
+                        help='Number of processors to use', default=1)
+    args = parser.parse_args()
+    num_procs = args.num_procs
+
+    # read in the points extract data
+    point_data = ascii.read('extracts/point_extractor_by_frame'
+                            '_box_the_jets_scaled_squashed_merged.csv')
+
+    # read in the box extracts data
+    box_data = ascii.read('extracts/shape_extractor_rotateRectangle'
+                          '_box_the_jets_scaled_squashed_merged.csv')
+
+    # find the list of subjects from both point and box data
+    subjects = set(np.unique(box_data['subject_id'])).\
+        intersection(set(np.unique(point_data['subject_id'])))
+
+    # build the reduction export list by looping over the subjects
+    out_data = []
+
+    with Pool(processes=num_procs, initializer=initializer) as pool:
+
+        # loop through each subject and get the corresponding
+        # rows from the point and box extractors
+        inpargs = []
+        for subject in tqdm.tqdm(subjects, desc='Loading subjects', ascii=True):
+            box_data_sub = box_data[box_data['subject_id'] == subject]
+            point_data_sub = point_data[point_data['subject_id'] == subject]
+
+            # find the rows where there is data
+            # here we check whether the frame info is filled
+            data_frame = np.asarray(box_data_sub['data.frame0.T1_tool2_frame'].filled())
+            mask = np.where(data_frame != 'N/A')[0]
+            box_rows = box_data_sub[mask]
+
+            data_frame0 = np.asarray(point_data_sub['data.frame0.T1_tool0_frame'].filled())
+            data_frame1 = np.asarray(point_data_sub['data.frame0.T1_tool1_frame'].filled())
+            mask = np.where((data_frame0 != 'N/A')&(data_frame1 != 'N/A'))[0]
+            point_rows = point_data_sub[mask]
+
+            if (len(box_rows) > 0)&(len(point_rows) > 0):
+                inpargs.append([box_rows, point_rows, subject])
+
+        try:
+            # run this through the multiprocessing pipeline
+            r = pool.starmap_async(_do_reduction, inpargs, chunksize=10)
+
+            pool.close()
+        
+            tasks = pool._cache[r._job]
+            ninpt = len(inpargs)
+
+            # print a progress bar
+            with tqdm.tqdm(total=ninpt, desc='Doing reduction', ascii=True) as pbar:
+                while tasks._number_left > 0:
+                    pbar.n = max([ninpt - tasks._number_left * tasks._chunksize, 0])
+                    pbar.refresh()
+
+                    time.sleep(0.1)
+        except Exception as e:
+            print(e)
+            pool.terminate()
+            pool.join()
+        except KeyboardInterrupt:
+            pool.terminate()
+            pool.join()
+        finally:
+            pool.join()
+
+
+        results = r.get()
+
+        # save out each row to a list
+        for jj, out_row in enumerate(results):
+            out_data.append(out_row)
+
+    # save the list to a JSON
+    with open('reductions/reductions.json', 'w') as outfile:
+        json.dump(out_data, outfile, cls=NpEncoder)

--- a/BoxTheJets/scripts/do_reduction.py
+++ b/BoxTheJets/scripts/do_reduction.py
@@ -43,8 +43,8 @@ def _do_reduction(box_data_sub, point_data_sub, subject):
     # do the reduction
     box_reduction = shape_reducer_dbscan(ext_data, metric_type='IoU',
                                shape='rotateRectangle', user_id=False,
-                               allow_single_cluster=True, min_samples=2,
-                               min_cluster_size=2, eps=0.5)
+                               allow_single_cluster=True, min_samples=3,
+                               min_cluster_size=3, eps=0.5)
 
     box_out = {}
     box_out['extracts'] = defaultdict(list,
@@ -100,8 +100,8 @@ def _do_reduction(box_data_sub, point_data_sub, subject):
      
     # do the reduction
     point_reduction = point_reducer_hdbscan(ext_data, user_id=False, 
-                               allow_single_cluster=True, min_samples=2,
-                                min_cluster_size=2)
+                               allow_single_cluster=True, min_samples=3,
+                                min_cluster_size=3)
     points_out = {}
     points_out['start'] = {}
     points_out['end'] = {}


### PR DESCRIPTION
Currently, the frametime information of a classification (box or point) is lost during the merging stage. This PR modifies the extraction/reduction pipeline to include the frame information as part of each reducer output.

Note: this PR is not modifying the `get_frame_info` method, so we're not actually using the frame info yet -- just extracting it.

The major modification is in using a new `do_reduction.py` script to do the reduction rather than the `panoptes_aggregation` module. Implicitly the new script runs the `panoptes_aggregation` reducers per subject but preserves the frame information as part of the output. The output reduction are now in a JSON format rather than a CSV.